### PR TITLE
flow.parallel won't end now on error.

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ var parallel = pull.Through(function (read, hwm, lwm) {
 
     ;(function drain() {
       if((output.length || ended) && cbs.length)
-        cbs.shift() (output.length ? null : ended, output.shift())
+        cbs.shift() (output.length ? output[0].end : ended, output.shift().data)
       else if(!ended){
         var m = n + output.length
         if(m >= lwm) return
@@ -26,8 +26,8 @@ var parallel = pull.Through(function (read, hwm, lwm) {
             async = false
             n--
             //console.log('--->', n, end, data)
-            if(!(ended = ended || end))
-              output.push(data)
+            if(!(end === true && (ended = ended || end)))
+              output.push({end:end, data:data})
             drain()
           })
         }


### PR DESCRIPTION
The pull request is related to this issue:
https://github.com/dominictarr/pull-stream/issues/19

You can test the changes with the following code:

``` js
var pull = require("pull-stream");
var flow = require("pull-flow");

var randomErrorStream = pull.Source( function () {
  var counter = 0;
  return function (end, cb) {
    if (Math.round(Math.random() * 3) === 0) return cb(new Error("dummy"));
    setTimeout( function () {
      cb(null, ++counter);
    }, Math.round(Math.random() * 1000));
  }
})

pull(
  randomErrorStream(),
  flow.serial(),
  pull.map(function (d) {return d+1}),
  flow.parallel(10),
  pull.Through( function (read) {
    return function next (end, cb) {
      read(end,  function (end, data) {
        if (end === true) { return cb(end)};
        if (end) { console.error(end); return next(null, cb);}
        return cb(end, data);
      });
    }
  })(),
  pull.log()
)
```
