### PR TITLE
Solved some bugs that happens from async sources...

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ var parallel = pull.Through(function (read, hwm, lwm) {
 
     ;(function drain() {
       if((output.length || ended) && cbs.length)
-        cbs.shift() (output.length ? null : ended, output.shift())
+        cbs.shift() (output.length ? output[0].end : ended, output.shift().data)
       else if(!ended){
         var m = n + output.length
         if(m >= lwm) return
@@ -26,8 +26,8 @@ var parallel = pull.Through(function (read, hwm, lwm) {
             async = false
             n--
             //console.log('--->', n, end, data)
-            if(!(ended = ended || end))
-              output.push(data)
+            if(!(end === true && (ended = ended || end)))
+              output.push({end:end, data:data})
             drain()
           })
         }

--- a/index.js
+++ b/index.js
@@ -10,9 +10,10 @@ var parallel = pull.Through(function (read, hwm, lwm) {
     cbs.push(cb)
 
     ;(function drain() {
-      if((output.length || ended) && cbs.length)
-        cbs.shift() (output.length ? output[0].end : ended, output.shift().data)
-      else if(!ended){
+      if((output.length || ended) && cbs.length) {
+        var inFlight = output.shift();
+        cbs.shift() (inFlight ? inFlight.end : ended, inFlight && inFlight.data)
+      } else if(!ended){
         var m = n + output.length
         if(m >= lwm) return
 
@@ -26,8 +27,8 @@ var parallel = pull.Through(function (read, hwm, lwm) {
             async = false
             n--
             //console.log('--->', n, end, data)
-            if(!(end === true && (ended = ended || end)))
-              output.push({end:end, data:data})
+            if(!(end === true && (ended = ended || end))) {
+              output.push({end:end, data:data})}
             drain()
           })
         }

--- a/index.js
+++ b/index.js
@@ -42,12 +42,15 @@ var serial = pull.Through(function (read) {
 
   return function (end, cb) {
     queue.push({end: end, cb: cb})
-    if(queue.length > 1) return
+    if(queue.length > 1 || inFlight) return
 
     ;(function drain() {
-      read(queue[0].end, function (end, data) {
-        var cb = queue.shift().cb
+      if (inFlight) return;
+      inFlight = queue.shift()
+      read(inFlight.end, function (end, data) {
+        var cb = inFlight.cb
         cb(end, data)
+        inFlight = null;
         if(queue.length) drain()
       })
     })()


### PR DESCRIPTION
for `flow.serial()`, the following code would throw an error:

``` js
pull(
  pull.values([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20]),
  flow.async(),
  flow.serial(),
  pull.log()
)
```

Basically the problem here is by using the following code:

``` js
output[0].end, output.shift().cb
```

The error happens when reading from async sources. I believe that it happens because of messing up with object references. Something internal for node.

regarding `flow.parallel`, the following code would throw an error:

``` js
pull(
  pull.values([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20]),
  flow.async(),
  flow.serial(),
  flow.async(),
  flow.parallel(10),
  pull.log()
)
```

Again, some problems reading from async sources. Some reference errors.

And finally, I changed the way it does error handling.

If an error bubbles up from a reader/sink, the stream would end immediately. In case an error happened while reading readable, the error would be sent to the sink, but it won't stop executing.
